### PR TITLE
Fix error name typo

### DIFF
--- a/packages/hardhat/contracts/BlockMagicians.sol
+++ b/packages/hardhat/contracts/BlockMagicians.sol
@@ -33,7 +33,8 @@ contract BlockMagicians is ERC721, Ownable {
   
   event minted (address owner, uint256 id);
 
-  error NotEnouhgETH();
+  /// Thrown when `msg.value` is lower than the required mint fee.
+  error NotEnoughETH();
   error Fail2SendETH();
   error AllMagiciansMinted();
 
@@ -46,7 +47,7 @@ contract BlockMagicians is ERC721, Ownable {
       public
       returns (uint256)
   {
-      if (msg.value < MINT_FEE) revert NotEnouhgETH();
+      if (msg.value < MINT_FEE) revert NotEnoughETH();
       if (molochHealth == 0) revert AllMagiciansMinted();
       
       _tokenIds.increment();

--- a/packages/nextjs/contracts/deployedContracts.ts
+++ b/packages/nextjs/contracts/deployedContracts.ts
@@ -26,7 +26,7 @@ const deployedContracts = {
         },
         {
           inputs: [],
-          name: "NotEnouhgETH",
+          name: "NotEnoughETH",
           type: "error",
         },
         {


### PR DESCRIPTION
## Summary
- fix `NotEnouhgETH` typo in BlockMagicians.sol
- update generated ABI with new error name

## Testing
- `npm test --workspaces --if-present` *(fails: hardhat not found)*

------
https://chatgpt.com/codex/tasks/task_e_68463cb180e48328a2b7997298f65939