### PR TITLE
Fix View NFT page default export

### DIFF
--- a/packages/nextjs/app/view-nfts/page.tsx
+++ b/packages/nextjs/app/view-nfts/page.tsx
@@ -14,3 +14,5 @@ const ViewNFTs: NextPage = () => {
   return <ViewNFTsClient />;
 };
 
+export default ViewNFTs;
+


### PR DESCRIPTION
## Summary
- export `ViewNFTs` as default from page file

## Testing
- `yarn test` *(fails: Proxy response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6846780d8e3483289ebdf9d36c37fbee