### PR TITLE
Add About page and rename app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# 🏗 Scaffold-ETH 2
+# 🪄 Block Magicians
+
+Block Magicians is a playful DApp built on top of Scaffold‑ETH 2. Mint magical NFTs representing your
+favorite blockchain protocols and help defeat Moloch while supporting Web3 builders.
 
 some links usefull links:
 https://github.com/Quanhua-Guan/scaffold-eth-2/tree/eeemay/oh-pandas-meme
@@ -33,13 +36,13 @@ Before you begin, you need to install the following tools:
 
 ## Quickstart
 
-To get started with Scaffold-ETH 2, follow the steps below:
+To get started with Block Magicians, follow the steps below:
 
 1. Clone this repo & install dependencies
 
 ```
-git clone https://github.com/scaffold-eth/scaffold-eth-2.git
-cd scaffold-eth-2
+git clone <your-repo-url>
+cd blockMagiciansNFT
 yarn install
 ```
 
@@ -76,12 +79,12 @@ Visit your app on: `http://localhost:3000`. You can interact with your smart con
 
 ## Documentation
 
-Visit our [docs](https://docs.scaffoldeth.io) to learn how to start building with Scaffold-ETH 2.
+Visit the [Scaffold-ETH docs](https://docs.scaffoldeth.io) to learn how this starter kit works.
 
 To know more about its features, check out our [website](https://scaffoldeth.io).
 
-## Contributing to Scaffold-ETH 2
+## Contributing
 
-We welcome contributions to Scaffold-ETH 2!
+We welcome contributions!
 
-Please see [CONTRIBUTING.MD](https://github.com/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) for more information and guidelines for contributing to Scaffold-ETH 2.
+Please see [CONTRIBUTING.MD](https://github.com/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) for more information and guidelines for contributing.

--- a/packages/hardhat/test/YourContract.ts
+++ b/packages/hardhat/test/YourContract.ts
@@ -19,7 +19,7 @@ describe("YourContract", function () {
     });
 
     it("Should allow setting a new message", async function () {
-      const newGreeting = "Learn Scaffold-ETH 2! :)";
+      const newGreeting = "Learn Block Magicians! :)";
 
       await yourContract.setGreeting(newGreeting);
       expect(await yourContract.greeting()).to.equal(newGreeting);

--- a/packages/nextjs/app/about/page.tsx
+++ b/packages/nextjs/app/about/page.tsx
@@ -1,0 +1,22 @@
+import type { NextPage } from "next";
+import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
+
+export const metadata = getMetadata({
+  title: "About",
+  description: "Learn more about Block Magicians",
+});
+
+const About: NextPage = () => {
+  return (
+    <div className="max-w-2xl mx-auto p-6 text-center">
+      <h1 className="text-4xl font-bold mb-4">About Block Magicians</h1>
+      <p className="text-lg">
+        Block Magicians is a playful dApp that lets you mint magical NFTs representing
+        different blockchain protocols. Each mint weakens Moloch while supporting the
+        BuidlGuidl and independent Web3 developers. Join the fight and collect them all!
+      </p>
+    </div>
+  );
+};
+
+export default About;

--- a/packages/nextjs/app/blockexplorer/layout.tsx
+++ b/packages/nextjs/app/blockexplorer/layout.tsx
@@ -2,7 +2,7 @@ import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
 
 export const metadata = getMetadata({
   title: "Block Explorer",
-  description: "Block Explorer created with 🏗 Scaffold-ETH 2",
+  description: "Block Explorer created for Block Magicians",
 });
 
 const BlockExplorerLayout = ({ children }: { children: React.ReactNode }) => {

--- a/packages/nextjs/app/debug/page.tsx
+++ b/packages/nextjs/app/debug/page.tsx
@@ -4,7 +4,7 @@ import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
 
 export const metadata = getMetadata({
   title: "Debug Contracts",
-  description: "Debug your deployed 🏗 Scaffold-ETH 2 contracts in an easy way",
+  description: "Debug your deployed Block Magicians contracts in an easy way",
 });
 
 const Debug: NextPage = () => {

--- a/packages/nextjs/app/layout.tsx
+++ b/packages/nextjs/app/layout.tsx
@@ -5,8 +5,8 @@ import "~~/styles/globals.css";
 import { getMetadata } from "~~/utils/scaffold-eth/getMetadata";
 
 export const metadata = getMetadata({
-  title: "Scaffold-ETH 2 App",
-  description: "Built with 🏗 Scaffold-ETH 2",
+  title: "Block Magicians",
+  description: "Mint magical NFTs and defeat Moloch",
 });
 
 const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -28,6 +28,10 @@ export const menuLinks: HeaderMenuLink[] = [
     label: "View NFTs",
     href: "/view-nfts",
   },
+  {
+    label: "About",
+    href: "/about",
+  },
 ];
 
 export const HeaderMenuLinks = () => {
@@ -68,7 +72,7 @@ export const Header = () => {
   );
 
   return (
-    <div className="sticky lg:static top-0 navbar bg-base-100 min-h-0 flex-shrink-0 justify-between z-20 shadow-md shadow-secondary px-0 sm:px-2">
+    <div className="sticky lg:static top-0 navbar bg-black bg-opacity-30 backdrop-blur-md min-h-0 flex-shrink-0 justify-between z-20 shadow-md shadow-secondary px-0 sm:px-2">
       <div className="navbar-start w-auto lg:w-1/2">
         <div className="lg:hidden dropdown" ref={burgerMenuRef}>
           <label
@@ -97,8 +101,8 @@ export const Header = () => {
             <Image alt="SE2 logo" className="cursor-pointer" fill src="/logo.svg" />
           </div>
           <div className="flex flex-col">
-            <span className="font-bold leading-tight">Scaffold-ETH</span>
-            <span className="text-xs">Ethereum dev stack</span>
+            <span className="font-bold leading-tight">Block Magicians</span>
+            <span className="text-xs">NFT wizardry</span>
           </div>
         </Link>
         <ul className="hidden lg:flex lg:flex-nowrap menu menu-horizontal px-1 gap-2">

--- a/packages/nextjs/public/manifest.json
+++ b/packages/nextjs/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Scaffold-ETH 2 DApp",
-  "description": "A DApp built with Scaffold-ETH",
+  "name": "Block Magicians",
+  "description": "A DApp to mint magical NFTs",
   "iconPath": "logo.svg"
 }

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -9,6 +9,7 @@
 
 body {
   min-height: 100vh;
+  @apply bg-gradient-to-br from-indigo-900 via-purple-900 to-black text-white;
 }
 
 h1,

--- a/packages/nextjs/utils/scaffold-eth/getMetadata.ts
+++ b/packages/nextjs/utils/scaffold-eth/getMetadata.ts
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 const baseUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
   ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
   : `http://localhost:${process.env.PORT || 3000}`;
-const titleTemplate = "%s | Scaffold-ETH 2";
+const titleTemplate = "%s | Block Magicians";
 
 export const getMetadata = ({
   title,


### PR DESCRIPTION
## Summary
- rename metadata and header from Scaffold-ETH to Block Magicians
- add About page with project description
- style header and global background
- update README with new app name and instructions
- adjust manifest and metadata

## Testing
- `yarn test` *(fails: Request was cancelled due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684bb236d38083289acdebd2e0a2a996